### PR TITLE
fix for clustering environments and ajaxflow grails plugin

### DIFF
--- a/grails-app/domain/org/grails/plugins/localization/Localization.groovy
+++ b/grails-app/domain/org/grails/plugins/localization/Localization.groovy
@@ -8,7 +8,7 @@ import org.springframework.web.context.support.WebApplicationContextUtils
 import org.springframework.web.servlet.support.RequestContextUtils
 import org.codehaus.groovy.grails.commons.ApplicationHolder
 
-class Localization {
+class Localization implements Serializable {
 
     private static loaded = false
     private static cache = new LinkedHashMap((int) 16, (float) 0.75, (boolean) true)


### PR DESCRIPTION
Made domain class implement Serializable - this is a fix for clustering environments and ajaxflow grails plugin (and webflows) which require serializing the domain objects into the session. Terracotta also uses this to cache Hibernate objects as well.
