### PR TITLE
Enable use config for Localization mapping

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -12,7 +12,7 @@ grails.project.dependency.resolution = {
     dependencies { 
     }
     plugins {
-      build(":tomcat:$grailsVersion",
+      build(":tomcat:7.0.55.2",
             ":release:2.2.0") {
         export = false
       }

--- a/grails-app/domain/org/grails/plugins/localization/Localization.groovy
+++ b/grails-app/domain/org/grails/plugins/localization/Localization.groovy
@@ -4,6 +4,7 @@ package org.grails.plugins.localization
 import grails.util.GrailsWebUtil
 import grails.util.Environment
 import grails.util.BuildSettingsHolder
+import grails.util.Holders
 import org.codehaus.groovy.grails.plugins.GrailsPluginUtils
 import org.codehaus.groovy.grails.web.context.ServletContextHolder
 import org.springframework.web.context.request.RequestContextHolder
@@ -28,7 +29,7 @@ class Localization implements Serializable {
     Date dateCreated
     Date lastUpdated    
 
-    static mapping = {
+    static mapping = Holders.config.grails.plugin.localizations.mapping ?: {
         columns {
             code index: "localizations_idx"
             locale column: "loc"


### PR DESCRIPTION
Here's the pull request to enable mapping in config. Discussed in https://github.com/halfbaked/grails-localizations/issues/19

Also tomcat:$grailsVersion was failing because there's no tomcat 2.5.1 version.